### PR TITLE
Implemented support for multiple abc scripts parallel execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ YOSYS_SRC := $(dir $(firstword $(MAKEFILE_LIST)))
 VPATH := $(YOSYS_SRC)
 
 CXXSTD ?= c++11
-CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
-LDLIBS := $(LDLIBS) -lstdc++ -lm
+CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include 
+LDLIBS := $(LDLIBS) -lstdc++ -lm -pthread
 PLUGIN_LDFLAGS :=
 
 PKG_CONFIG ?= pkg-config

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -135,6 +135,7 @@ void run_command(const std::string &command, vector<int>& results, std::map<std:
         char logbuf[128];
         while (fgets(logbuf, 128, f) != NULL) {
             log_results[command]+=logbuf;
+        }
 
         int ret = pclose(f);
         if (ret < 0)
@@ -175,6 +176,8 @@ RTLIL::Design* cost(const vector<RTLIL::Design*>& mapped_designs, const std::str
 void abc_output_process_line(const std::string& script, std::function<void(const std::string&)> process_line){
 
           std::string line;
+        //char logbuf[128];
+       // while (fgets(logbuf, 128, f) != NULL) {
           for(auto it: split_tokens(script,"\n")){
 	        line+=(it+"\n");  
 		if (!line.empty() && line.back() == '\n'){


### PR DESCRIPTION
The following has been done:

- Rewrited the `run_command` function to add a support for running multiple abc  scripts in parallel
- Implemented `area_cost_func` function to find and pick the results based on minimum numbers of luts
- Implemented `abc_output_process_line` function to print logs only of the picked script's run

Done runs in parallel and non parallel mode of abc_base.a20.scr,abc_base.a21.scr scripts and created a QoR table compared with parallel run results. Please find it attached.
[parallel_QoR.xls](https://github.com/RapidSilicon/yosys_rs/files/8254820/parallel_QoR.xls)

