### PR TITLE
Updated the error message

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1129,7 +1129,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		std::ifstream ifs;
 		ifs.open(buffer);
 		if (ifs.fail())
-			log_error("ERROR: something went wrong in DE LUT mapper (hint: please make sure you have DE license).");
+			log_error("ERROR: something went wrong in DE LUT mapper");
 
 		bool builtin_lib = liberty_files.empty() && genlib_files.empty();
 		RTLIL::Design *mapped_design = new RTLIL::Design;


### PR DESCRIPTION
Changed the "blif file missing" error message to the advised one "ERROR: something went wrong in DE LUT mapper (hint: please make sure you have DE license).".