### PR TITLE
Fixed GEMINIEDA-484 "Synthesis : handling assert construct in VHDL"

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -2612,7 +2612,7 @@ struct VerificPass : public Pass {
 			RuntimeFlags::SetVar("vhdl_allow_any_ram_in_loop", 1);
 
 			RuntimeFlags::SetVar("vhdl_support_variable_slice", 1);
-			RuntimeFlags::SetVar("vhdl_ignore_assertion_statements", 0);
+			RuntimeFlags::SetVar("vhdl_ignore_assertion_statements", 1);
 
 			RuntimeFlags::SetVar("vhdl_preserve_assignments", 1);
 			//RuntimeFlags::SetVar("vhdl_preserve_comments", 1);


### PR DESCRIPTION
The following has been done:

- Have changed the state of the "vhdl_ignore_assertion_statements" flag from 0 to 1, to prevent the assert primitive from being created.