### PR TITLE
CASTORIP-121: Write blif with big endian parameters.

### DIFF
--- a/backends/blif/blif.cc
+++ b/backends/blif/blif.cc
@@ -167,6 +167,7 @@ struct BlifDumper
 						f << stringf("%c", ch);
 				f << stringf("\"\n");
 			} else
+				// RapidSilicon: CASTORIP-121
 				if (littleEndian) {
 					f << stringf("%s\n", param.second.as_string().c_str());
 				} else {


### PR DESCRIPTION
Write parameter in big endian for Genesis2 primitives in Blif format. This change is addressing the [CASTORIP-121](https://rapidsilicon.atlassian.net/browse/CASTORIP-121) jira. 