### PR TITLE
EDA-880: Mark merged dff memories.

### DIFF
--- a/passes/memory/memory_dff.cc
+++ b/passes/memory/memory_dff.cc
@@ -620,6 +620,7 @@ struct MemoryDffWorker
 		for (auto wpIdx : wpIdxVec)
 			port.transparency_mask[wpIdx] = true;
 		mem.emit();
+		mem.set_bool_attribute(RTLIL::escape_id("dff_merge"));
 		log("merged address FF to cell.\n");
 	}
 


### PR DESCRIPTION
This change is linked with [#125](https://github.com/RapidSilicon/yosys-rs-plugin/pull/125) PR.