### PR TITLE
Fixed the EDA-1066

### DIFF
--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -2025,6 +2025,11 @@ struct MemoryLibMapPass : public Pass {
 		opts.no_auto_block = false;
 		opts.no_auto_huge = false;
 		opts.logic_cost_ram = 1.0;
+		/*Lilit*
+		 * The threshold value for logic_cost_rom has been choosen according 
+		 * to the experiments that have been done by comparing BRAM inference 
+		 * with Vivado in the scope of EDA-1066 issue
+		 */
 		opts.logic_cost_rom = 0.3;
 		log_header(design, "Executing MEMORY_LIBMAP pass (mapping memories to cells).\n");
 


### PR DESCRIPTION
The following has been done:

- Changed the threshold value for logic_cost_rom according to the experiments that have been done by comparing BRAM  inference with Vivado