### PR TITLE
Fixed the BRAM part of the EDA-117 issue

### DIFF
--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -2045,7 +2045,7 @@ struct MemoryLibMapPass : public Pass {
 				continue;
 			}
 			if (args[argidx] == "-limit" && argidx+1 < args.size()) {
-				limit_b = stoi(args[++argidx]);
+				limit_b = std::stoi(args[++argidx]);
 				continue;
 			}
 			if (args[argidx] == "-D" && argidx+1 < args.size()) {


### PR DESCRIPTION
The following has been done:

- Added the `-limit` flag to specify maximum number of inferred BRAMs