### PR TITLE
Fix for EDA-806

### DIFF
--- a/passes/memory/memory_dff.cc
+++ b/passes/memory/memory_dff.cc
@@ -504,7 +504,6 @@ struct MemoryDffWorker
 
 		// OK, it worked.
 		log("merging output FF to cell.\n");
-		mem.set_bool_attribute(RTLIL::escape_id("dff_merge"));
 
 		merger.remove_output_ff(bits);
 		if (ff.has_ce && !ff.pol_ce)


### PR DESCRIPTION
This PR is created to implement soft logic for TDP read first memory, as read first behaviour for TDP ram cannot be mulated because of BRAM architecture restriction