### PR TITLE
Reverted changes regarding EDA-1066 issue

### DIFF
--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -2060,7 +2060,8 @@ struct MemoryLibMapPass : public Pass {
 		 * to the experiments that have been done by comparing BRAM inference 
 		 * with Vivado in the scope of EDA-1066 issue
 		 */
-		opts.logic_cost_rom = 0.3;
+		//opts.logic_cost_rom = 0.3;
+		opts.logic_cost_rom = 1.0/16.0;
 		log_header(design, "Executing MEMORY_LIBMAP pass (mapping memories to cells).\n");
 
 		size_t argidx;


### PR DESCRIPTION
Changed the logic_cost_rom value from 0.3 to the original 1.0/16.0