### PR TITLE
put FF explicit names, close EDA-1282

### DIFF
--- a/kernel/ff.cc
+++ b/kernel/ff.cc
@@ -280,9 +280,9 @@ FfData FfData::slice(const std::vector<int> &bits) {
 	//
         IdString newId;
 
-	if (GetSize(sig_q) == 1) {
+	if (bits.size() == 1) {
 
-          SigBit sigQ = sig_q;
+          SigBit sigQ = sig_q[0];
 
           string FfQname = sigTostring(sigQ);
 


### PR DESCRIPTION
verified on Golden suite on Genesis 3 with correct exit. Complains on DFF SR by listing explicit DFF names.