### PR TITLE
EDA-1436 Fix: Map memry with asyncronous read to soft logic

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -98,6 +98,7 @@ std::vector<void*> memhasher_store;
 std::string yosys_share_dirname;
 std::string yosys_abc_executable;
 std::string yosys_shared_tmp_dirname;
+bool mem_async_read= false;
 
 void init_share_dirname();
 void init_abc_executable_name();

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -291,7 +291,7 @@ int GetSize(RTLIL::Wire *wire);
 
 extern int autoidx;
 extern int yosys_xtrace;
-
+extern bool mem_async_read;
 YOSYS_NAMESPACE_END
 
 #include "kernel/log.h"

--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -437,6 +437,12 @@ void MemMapping::determine_style() {
 	}
 	for (auto attr: {ID::ram_block, ID::rom_block, ID::ram_style, ID::rom_style, ID::ramstyle, ID::romstyle, ID::syn_ramstyle, ID::syn_romstyle}) {
 		if (mem.has_attribute(attr)) {
+			// Begin: Awais: Fix for EDA-1436: (Map memory with async read to soft logic when inline attribute is block)
+			if (mem_async_read){
+				log_warning("Asyncronous read in BRAM is not supported, memory will be mapped to soft logic.\n");
+				mem.set_string_attribute(attr,"logic");
+			}
+			// End: Awais: Fix for EDA-1436: (Map memory with async read to soft logic when inline attribute is block)
 			Const val = mem.attributes.at(attr);
 			if (val == 1) {
 				kind = RamKind::NotLogic;


### PR DESCRIPTION
This PR will fix EDA-1436: memory with asyncronous read will be mapped to soft logic when Verilog inline attribute is "block"