### PR TITLE
Included the IO primitives and string value support for parameters

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -185,22 +185,21 @@ void set_instance_parameters(Design *design)
 						log("Setting parameter %s to %s for %s cell.\n", k, v, cell.second->name.c_str());
 					size_t len = strlen(v);
 					if (!containsOnlyAlphabets(v)){ // if 'v' (pram value) contains digit then we follow default binary conversion
-					for (int i = len - 1; i >= 0; --i) {
-						if (v[i] == 'b')
-							break;
-						bits.push_back(v[i] == '1');
-					}
-					paramValue = Const(bits);
+						for (int i = len - 1; i >= 0; --i) {
+							if (v[i] == 'b')
+								break;
+							bits.push_back(v[i] == '1');
+						}
+						paramValue = Const(bits);
 					}
 					// if we reach in else condition here, then param value would be string.
 					/* Begin- EDA-1419 string param value support */
 					else {
-					char* updated = updateMiddleChars(v); //here remove the double qoutes
-					paramValue = Const(updated);
-					delete[]updated;
+						char* updated = updateMiddleChars(v); //here remove the double qoutes
+						paramValue = Const(updated);
+						delete[]updated;
 					}
 					/* END- EDA-1419 string param value support */
-
 					IdString paramName = IdString(std::string("\\") + k);
 					cell.second->setParam(paramName, paramValue);
 				}


### PR DESCRIPTION
Hi @thierryBesson  and @aram-rs, 
I have extended the function set_instance_parameter function to include the string parameters as well. Now I am getting correct string values in the netlist. Please review the code that I have added here for handling the "string" parameter values.

**Provided in RTL:**
I_BUF #(
         .PULL_UP_DOWN("NONE" ),
         .SLEW_RATE("SLOW"), 
         .DELAY(1),.REG_EN("FALSE" )
) 
    a0_sig (.I(a[0]),.C(),.O(a_in[0]));
    
 **Getting in Netlist**
  I_BUF #(
    .DELAY(1'b1),
    .PULL_UP_DOWN("NONE"),
    .REG_EN("FALSE"),
    .SLEW_RATE("SLOW")
  ) a0_sig (
    .I(a[0]),
    .O(a_in[0])
  );
  
  Regards,