### PR TITLE
Initialize momory with all zero as per EDA-1635

### DIFF
--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -430,7 +430,8 @@ void Mem::coalesce_inits() {
 }
 
 Const Mem::get_init_data() const {
-	Const init_data(State::Sx, width * size);
+	// Komal: Initiazing BRAM with State::S0, originaly State::Sx as per EDA-1635
+	Const init_data(State::S0, width * size);
 	for (auto &init : inits) {
 		if (init.removed)
 			continue;

--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -2007,7 +2007,8 @@ void MemMapping::emit(const MemConfig &cfg) {
 				for (int hwa = 0; hwa < (1 << cfg.def->abits); hwa += 1 << (GetSize(cfg.def->dbits) - 1)) {
 					for (auto &bit: init_swz.bits[rd]) {
 						if (!bit.valid) {
-							initval.push_back(State::Sx);
+							// Komal: Initialize invalid bits of memory to zero as per EDA-1635
+							initval.push_back(State::S0);
 						} else {
 							int addr = bit.addr;
 							for (int i = GetSize(cfg.def->dbits) - 1; i < cfg.def->abits; i++)
@@ -2015,8 +2016,10 @@ void MemMapping::emit(const MemConfig &cfg) {
 									addr += 1 << hw_addr_swizzle[i];
 							if (addr >= mem.start_offset && addr < mem.start_offset + mem.size)
 								initval.push_back(init_data.bits[(addr - mem.start_offset) * mem.width + bit.bit]);
-							else
-								initval.push_back(State::Sx);
+							else {
+								// Komal: Initialize BRAM's uninitialized bits with zeros as per EDA-1635
+								initval.push_back(State::S0);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This PR will fix EDA-1635, which requires to initialize memory with all zeros.