### PR TITLE
Made changes for handling the parity bit placement

### DIFF
--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -1170,6 +1170,7 @@ void MemMapping::handle_geom() {
 				while (GetSize(swizzle) % effective_byte)
 					swizzle.push_back(-1);
 
+#if 0		//Ayyaz: It is disabled because, it is handled in BRAM technology mapping files under EDA-1776 & EDA-1777 fix	
 			// Correct the swizzles for specific case when BRAM will work on MODE_36
 			// Special handling of parity bit for RapidSilicon BRAM architecture
 			if(technology != ""){
@@ -1193,6 +1194,7 @@ void MemMapping::handle_geom() {
 					}
 				}
 			}
+#endif
 			// Now evaluate the configuration, then keep adding more hard wide bits
 			// and evaluating.
 			int hard_wide_mask = 0;
@@ -1554,8 +1556,6 @@ std::vector<SigSpec> generate_mux(Mem &mem, int rpidx, const Swizzle &swz) {
 
 void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, const PortVariant &pdef, const char *name, int wpidx, int rpidx, const std::vector<int> &hw_addr_swizzle) {
 	
-	int write_port_size;
-	int read_port_size;
 	for (auto &it: pdef.options)
 		for (auto cell: cells)
 			cell->setParam(stringf("\\PORT_%s_OPTION_%s", name, it.first.c_str()), it.second);
@@ -1700,30 +1700,13 @@ void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, cons
 			effective_byte = width;
 		if (wpidx != -1) {
 			auto &wport = mem.wr_ports[wpidx];                 			
-			write_port_size=GetSize(wport.data);
 			Swizzle port_swz = gen_swizzle(mem, cfg, wport.wide_log2, hw_wr_wide_log2);
 			std::vector<SigSpec> big_wren = generate_demux(mem, wpidx, port_swz);
 			for (int rd = 0; rd < cfg.repl_d; rd++) {
 				auto cell = cells[rd];
 				SigSpec hw_wdata;
 				SigSpec hw_wren;
-				// Ayyaz: This if block is added to handle  bit placement for Rapidsilicon Architecture for asymmetric BRAM
-			    if (mem.width < cfg.def->byte && write_port_size >= cfg.def->byte){
-					int count=0;
-					for (auto &bit : port_swz.bits[rd]) {
-						count++;
-						if (!bit.valid) {
-							if (count==effective_byte || count==3*effective_byte) continue;
-							else if (count==2*effective_byte ||count==4*effective_byte){
-							hw_wdata.append(State::Sx);
-							hw_wdata.append(State::Sx);
-							}
-						} else 
-							hw_wdata.append(wport.data[bit.bit]);
-					}
-				}
 				// original memory_libmap flow
-			    else{ 			
 				for (auto &bit : port_swz.bits[rd]) {
 					if (!bit.valid) {
 						hw_wdata.append(State::Sx);
@@ -1731,7 +1714,6 @@ void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, cons
 						hw_wdata.append(wport.data[bit.bit]);
 					}
 				}
-			    }
 				for (int i = 0; i < GetSize(port_swz.bits[rd]); i += effective_byte) {
 					auto &bit = port_swz.bits[rd][i];
 					if (!bit.valid) {
@@ -1778,7 +1760,6 @@ void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, cons
 		if (rpidx != -1) {
 			auto &rport = mem.rd_ports[rpidx];
 			auto &rpcfg = cfg.rd_ports[rpidx];
-			read_port_size=GetSize(rport.data);
 			Swizzle port_swz = gen_swizzle(mem, cfg, rport.wide_log2, hw_rd_wide_log2);
 			std::vector<SigSpec> big_rdata = generate_mux(mem, rpidx, port_swz);
 			for (int rd = 0; rd < cfg.repl_d; rd++) {
@@ -1843,24 +1824,7 @@ void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, cons
 				cell->setPort(stringf("\\PORT_%s_RD_DATA", name), hw_rdata);
 				SigSpec lhs;
 				SigSpec rhs;
-				//Ayyaz:  This if block is added to handle bit placement for Rapidsilicon Architecture for asymmetric BRAM
-				if (mem.width < cfg.def->byte && read_port_size >= cfg.def->byte ){
-					for (int i = 0; i < GetSize(hw_rdata); i++) {
-						auto &bit = port_swz.bits[rd][i];
-						if (bit.valid) {
-							lhs.append(big_rdata[bit.mux_idx][bit.bit]);
-							if(i==(2*cfg.def->byte-2) || i==(4*cfg.def->byte -2)) continue;
-							rhs.append(hw_rdata[i]);
-						}
-						else {
-							if (i==(cfg.def->byte -1) || i==(3*cfg.def->byte -1)){
-							rhs.append(hw_rdata[i]);
-							}
-						}
-					}
-				}
 				// Original memory_libmap flow
-				else{
 					for (int i = 0; i < GetSize(hw_rdata); i++) {
 						auto &bit = port_swz.bits[rd][i];
 						if (bit.valid) {
@@ -1868,7 +1832,6 @@ void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, cons
 							rhs.append(hw_rdata[i]);
 						}
 					}
-				}
 				mem.module->connect(lhs, rhs);
 			}
 		} else {


### PR DESCRIPTION
In this PR I have **removed** the code that was 

1. added by me for asymmetric ports and
2. added by @aram-rs  for handling byte write enable BRAM
I have done this because the existing code not properly handling the parity bit placement in the case of the byte write enable type BRAM for 36-bit wide ports and 18-bit wide ports. Now I have handled this parity bit placement in the techmap files of RS_TDP36K BRAM in Yosys-rs plugin.

Regards,