### PR TITLE
Add file and line info for Yosys Analyze with verilog input

### DIFF
--- a/backends/json/analyze.cc
+++ b/backends/json/analyze.cc
@@ -275,9 +275,9 @@ struct AnlzWriter
                       f << stringf(",\n");
                    }
                    f << stringf("              {\n");
-                   f << stringf("                   \"file\": \"1\",\n");
+                   f << stringf("                   \"file\": \"%d\",\n", module->fileID);
                    f << stringf("                   \"instName\": %s,\n", get_name(c->name).c_str());
-                   f << stringf("                   \"line\": 0,\n");
+                   f << stringf("                   \"line\": %d,\n", c->line);
                    f << stringf("                   \"module\":  %s,\n", get_name(c->type).c_str());
                    f << stringf("                   \"parameters\": []\n");
                    f << stringf("              }");
@@ -317,6 +317,14 @@ struct AnlzWriter
         void dump_fileIDs()
         {
 		f << stringf("  \"fileIDs\": {\n");
+                int fileID = 1;
+                for (std::vector<std::string>::iterator it = design->rtlFilesNames.begin(); 
+                    it != design->rtlFilesNames.end(); it++) {
+
+                    std::string fileName = *it;
+
+                    f << stringf("      \"%d\": \"%s\"\n", fileID++, fileName.c_str());
+                }
 		f << stringf("  },\n");
         }
 
@@ -325,7 +333,7 @@ struct AnlzWriter
 
                 // write file ID
                 //
-                f << stringf("          \"file\": \"1\",\n");
+                f << stringf("          \"file\": \"%d\",\n", module->fileID);
 
                 // write internalSignals
                 //
@@ -337,7 +345,7 @@ struct AnlzWriter
 
                 // write line
                 //
-                f << stringf("          \"line\": 0,\n");
+                f << stringf("          \"line\": %d,\n", module->line);
                      
                 if (dump_name) {
                   f << stringf("          \"module\": %s,\n", get_name(module->name).c_str());

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1938,6 +1938,10 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			// Set attribute 'module_not_derived' which will be cleared again after the hierarchy pass
 			cell->set_bool_attribute(ID::module_not_derived);
 
+                        // Store line of cell instance for Yosys "analyze" (Thierry)
+                        //
+                        cell->line = location.first_line;
+
 			for (auto it = children.begin(); it != children.end(); it++) {
 				AstNode *child = *it;
 				if (child->type == AST_CELLTYPE) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1032,6 +1032,13 @@ struct define_map_t;
 
 struct RTLIL::Design
 {
+        // For Yosys "analyze" version stores RTL file names with associated IDs
+        //
+        unsigned int rtlFilesId = 1;
+        std::map<std::string, unsigned int> rtlFiles;
+        std::vector<std::string> rtlFilesNames;
+        // (Thierry)
+
 	unsigned int hashidx_;
 	unsigned int hash() const { return hashidx_; }
 
@@ -1149,6 +1156,10 @@ protected:
 	void add(RTLIL::Process *process);
 
 public:
+        std::string fileName = "";
+        int fileID = 0;
+        int line = 0;
+
 	RTLIL::Design *design;
 	pool<RTLIL::Monitor*> monitors;
 
@@ -1507,6 +1518,10 @@ struct RTLIL::Memory : public RTLIL::AttrObject
 
 struct RTLIL::Cell : public RTLIL::AttrObject
 {
+        // Line info for Yosys "analyze" (Thierry)
+        //
+        unsigned int line = 0;
+
 	unsigned int hashidx_;
 	unsigned int hash() const { return hashidx_; }
 


### PR DESCRIPTION
Add file/line info in JSON files for verilog input.
I tested it on the "Raptor/tests/Testcases/aes_decrypt_fpga" design using many verilog files and it seems to work.