### PR TITLE
fix seg fault in GUI with analyze on VHDL

### DIFF
--- a/backends/json/analyze.cc
+++ b/backends/json/analyze.cc
@@ -254,6 +254,9 @@ struct AnlzWriter
                    if (c->name[0] == '$') {
                       continue;
                    }
+                   if (c->type[0] == '$') {
+                      continue;
+                   }
                    anyInst++;
                    break;
                 }
@@ -268,6 +271,9 @@ struct AnlzWriter
 		for (auto c : module->cells()) {
 
                    if (c->name[0] == '$') {
+                      continue;
+                   }
+                   if (c->type[0] == '$') {
                       continue;
                    }
 
@@ -400,8 +406,31 @@ struct AnlzWriter
 
 	void dump_modules(Module* topModule, std::set<RTLIL::Module*, IdString::compare_ptr_by_name<Module>>& used)
 	{
-                f << stringf("  \"modules\": {\n");
                 vector<Module*> modules = design->modules();
+                int nb_modules = 0;
+
+                // special case of no modules
+                //
+                for (auto module : modules) {
+
+                     if (module == topModule) {
+                        continue;
+                     }
+
+                     if (used.count(module) == 0) {
+                        continue;
+                     }
+
+                     nb_modules++;
+                     break;
+                }
+
+                if (!nb_modules) {
+                  f << stringf("  \"modules\": null");
+                  return;
+                }
+
+                f << stringf("  \"modules\": {\n");
 
                 bool first_module = true;
 


### PR DESCRIPTION
in GHDL we are apparently instantiating some internal cells starting with '$' and this is apparently creating seg. fault in the "analyze" client in GUI mode when "analyze" list these internal cells into the hier_info.json file.
Since also they are not user cells we do not list them in the json file and this looks to fix the seg.fault in GUI mode.