### PR TITLE
Enhance backend API to print signal name without space

### DIFF
--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -87,7 +87,7 @@ void RTLIL_BACKEND::dump_const(std::ostream &f, const RTLIL::Const &data, int wi
 	}
 }
 
-void RTLIL_BACKEND::dump_sigchunk(std::ostream &f, const RTLIL::SigChunk &chunk, bool autoint)
+void RTLIL_BACKEND::dump_sigchunk(std::ostream &f, const RTLIL::SigChunk &chunk, bool autoint, bool no_space)
 {
 	if (chunk.wire == NULL) {
 		dump_const(f, chunk.data, chunk.width, chunk.offset, autoint);
@@ -95,20 +95,20 @@ void RTLIL_BACKEND::dump_sigchunk(std::ostream &f, const RTLIL::SigChunk &chunk,
 		if (chunk.width == chunk.wire->width && chunk.offset == 0)
 			f << stringf("%s", chunk.wire->name.c_str());
 		else if (chunk.width == 1)
-			f << stringf("%s [%d]", chunk.wire->name.c_str(), chunk.offset);
+			f << stringf("%s%s[%d]", chunk.wire->name.c_str(), no_space ? "" : " ", chunk.offset);
 		else
-			f << stringf("%s [%d:%d]", chunk.wire->name.c_str(), chunk.offset+chunk.width-1, chunk.offset);
+			f << stringf("%s%s[%d:%d]", chunk.wire->name.c_str(), no_space ? "" : " ", chunk.offset+chunk.width-1, chunk.offset);
 	}
 }
 
-void RTLIL_BACKEND::dump_sigspec(std::ostream &f, const RTLIL::SigSpec &sig, bool autoint)
+void RTLIL_BACKEND::dump_sigspec(std::ostream &f, const RTLIL::SigSpec &sig, bool autoint, bool no_space)
 {
 	if (sig.is_chunk()) {
-		dump_sigchunk(f, sig.as_chunk(), autoint);
+		dump_sigchunk(f, sig.as_chunk(), autoint, no_space);
 	} else {
 		f << stringf("{ ");
 		for (auto it = sig.chunks().rbegin(); it != sig.chunks().rend(); ++it) {
-			dump_sigchunk(f, *it, false);
+			dump_sigchunk(f, *it, false, no_space);
 			f << stringf(" ");
 		}
 		f << stringf("}");

--- a/backends/rtlil/rtlil_backend.h
+++ b/backends/rtlil/rtlil_backend.h
@@ -32,8 +32,8 @@ YOSYS_NAMESPACE_BEGIN
 
 namespace RTLIL_BACKEND {
 	void dump_const(std::ostream &f, const RTLIL::Const &data, int width = -1, int offset = 0, bool autoint = true);
-	void dump_sigchunk(std::ostream &f, const RTLIL::SigChunk &chunk, bool autoint = true);
-	void dump_sigspec(std::ostream &f, const RTLIL::SigSpec &sig, bool autoint = true);
+	void dump_sigchunk(std::ostream &f, const RTLIL::SigChunk &chunk, bool autoint = true, bool no_space = false);
+	void dump_sigspec(std::ostream &f, const RTLIL::SigSpec &sig, bool autoint = true, bool no_space = false);
 	void dump_wire(std::ostream &f, std::string indent, const RTLIL::Wire *wire);
 	void dump_memory(std::ostream &f, std::string indent, const RTLIL::Memory *memory);
 	void dump_cell(std::ostream &f, std::string indent, const RTLIL::Cell *cell);


### PR DESCRIPTION
Enhance the YOSYS backend RTLIL API to print signal name without space if it is an array. 