### PR TITLE
Add string parameter in VHDL component

### DIFF
--- a/backends/vhdl/vhdl_backend.cc
+++ b/backends/vhdl/vhdl_backend.cc
@@ -2172,6 +2172,9 @@ bool unsupportedCell(string cellName)
    if (cellName == "I_BUF")
        return false;
 
+   if (cellName == "I_DELAY")
+       return false;
+
    if (cellName == "O_BUF")
        return false;
 
@@ -2588,18 +2591,17 @@ void dump_component(std::ostream &f, std::string indent, RTLIL::Cell *cell){
 	f << stringf("%s end component;",indent.c_str());
 }
 
-void lut_complex_expression(RTLIL::Module *module){
+
+void cell_complex_expression(RTLIL::Module *module){
 	for (auto cell : module->cells()) {
 		string cellName = id(cell->type, false);
-		if (isLUTx(cellName))
-		{ 	
+		if (isLUTx(cellName) || cell->type == RTLIL::escape_id("I_DELAY")){ 	
 			for (auto port : cell->connections()){
-				if (cell->input(port.first) && (port.first == RTLIL::escape_id("A"))){
+				if (port.second.size()>1){
 					RTLIL::Wire *new_wire=module->addWire(NEW_ID,GetSize(port.second));
 					module->connect( SigSpec(new_wire),port.second);
 					cell->setPort(port.first, SigSpec(new_wire));
 				}
-
 			}
 		}
     }
@@ -2615,7 +2617,7 @@ void vhdl_dump_components(std::ostream &f, std::string indent, RTLIL::Cell *cell
 }
 void vhdl_dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 {
-	lut_complex_expression(module);
+	cell_complex_expression(module);
 	reg_wires.clear();
 	reset_auto_counter(module);
 	active_module = module;

--- a/backends/vhdl/vhdl_backend.cc
+++ b/backends/vhdl/vhdl_backend.cc
@@ -2142,6 +2142,18 @@ bool unsupportedCell(string cellName)
    if (cellName == "TDP36K") 
        return false;
 
+   if (cellName == "DSP38") 
+       return false;
+
+   if (cellName == "DSP19X2") 
+       return false;
+
+   if (cellName == "TDP_RAM18KX2") 
+       return false;
+
+   if (cellName == "TDP_RAM36K") 
+       return false;
+
    if (cellName == "RS_DSP2_MULT") 
        return false;
 
@@ -2173,6 +2185,36 @@ bool unsupportedCell(string cellName)
        return false;
 
    if (cellName == "I_DELAY")
+       return false;
+
+   if (cellName == "BOOT_CLOCK")
+       return false;
+
+   if (cellName == "O_DELAY")
+       return false;
+
+   if (cellName == "I_SERDES")
+       return false;
+
+   if (cellName == "O_SERDES")
+       return false;
+
+   if (cellName == "O_BUF_DS")
+       return false;
+
+   if (cellName == "O_BUFT_DS")
+       return false;
+
+   if (cellName == "O_BUFT")
+       return false;
+
+   if (cellName == "O_DDR")
+       return false;
+
+   if (cellName == "LATCH")
+       return false;
+
+   if (cellName == "PLL")
        return false;
 
    if (cellName == "O_BUF")
@@ -2218,6 +2260,7 @@ void vhdl_dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
         // Print instance name and cell name to be instantiated
 	//
+	log("Cell = %s, Type = %s\n",log_id(cell->name),log_id(cell->type));
 	f << stringf("%s" "%s : %s \n", indent.c_str(), 
                      cellname(cell).c_str(), cellName.c_str());
 
@@ -2548,13 +2591,14 @@ void dump_component(std::ostream &f, std::string indent, RTLIL::Cell *cell){
 			if (n > 0)
 				f << stringf(";\n");
 			f << stringf("%s       %s: ",indent.c_str(),log_id(param.first));
-			
-			if ((param.second.flags & RTLIL::CONST_FLAG_STRING) != 0)
-				f << stringf("string := \"%s\"",param.second.decode_string().c_str());
-			else if ((param.second.flags & RTLIL::CONST_FLAG_SIGNED) != 0)
-				f << stringf("integer := 0");
-			else if ((param.second.flags & RTLIL::CONST_FLAG_REAL) != 0)
+			log("Cell = %s, Paramter = %s, Flag = %d,\n",log_id(cell->type),log_id(param.first),param.second.flags);
+			if ((param.second.flags & RTLIL::CONST_FLAG_REAL) == 4)
 				f << stringf("real := 0.0");
+			else if ((param.second.flags & RTLIL::CONST_FLAG_STRING) != 0)
+				f << stringf("string := \"%s\"",param.second.decode_string().c_str());
+			else if (((param.second.flags & RTLIL::CONST_FLAG_SIGNED) != 0) || param.second.flags == 0)
+				f << stringf("integer := 0");
+			
 			else if (param.second.size()>1){
 				f << stringf("std_logic_vector (%d downto 0)",param.second.size()-1);
 			}
@@ -2594,8 +2638,12 @@ void dump_component(std::ostream &f, std::string indent, RTLIL::Cell *cell){
 
 void cell_complex_expression(RTLIL::Module *module){
 	for (auto cell : module->cells()) {
-		string cellName = id(cell->type, false);
-		if (isLUTx(cellName) || cell->type == RTLIL::escape_id("I_DELAY")){ 	
+		string cellName = id(cell->type, true);
+		if (isLUTx(cellName) || cell->type == RTLIL::escape_id("I_DELAY") || cell->type == RTLIL::escape_id("O_DELAY")\
+				|| cell->type == RTLIL::escape_id("I_SERDES") || cell->type == RTLIL::escape_id("O_SERDES")\
+				|| cell->type == RTLIL::escape_id("TDP_RAM18KX2") || cell->type == RTLIL::escape_id("TDP_RAM36K")\
+				|| cell->type == RTLIL::escape_id("DSP19X2") || cell->type == RTLIL::escape_id("DSP38")\
+		){ 	
 			for (auto port : cell->connections()){
 				if (port.second.size()>1){
 					RTLIL::Wire *new_wire=module->addWire(NEW_ID,GetSize(port.second));

--- a/backends/vhdl/vhdl_backend.cc
+++ b/backends/vhdl/vhdl_backend.cc
@@ -53,6 +53,7 @@
 #include <sstream>
 #include <set>
 #include <map>
+#include <typeinfo>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -2544,7 +2545,11 @@ void dump_component(std::ostream &f, std::string indent, RTLIL::Cell *cell){
 			if (n > 0)
 				f << stringf(";\n");
 			f << stringf("%s       %s: ",indent.c_str(),log_id(param.first));
-			if (param.second.size()>1){
+			
+			if ((param.second.flags & RTLIL::CONST_FLAG_STRING) != 0)
+				f << stringf("string := \"%s\"",param.second.decode_string().c_str());
+
+			else if (param.second.size()>1){
 				f << stringf("std_logic_vector (%d downto 0)",param.second.size()-1);
 			}
 			else{
@@ -2571,8 +2576,8 @@ void dump_component(std::ostream &f, std::string indent, RTLIL::Cell *cell){
 		else{
 			f << stringf("std_logic");
 		}
-		if ((cell->input(conn.first)))
-			f << stringf(" := '0'");
+		// if ((cell->input(conn.first)))
+		// 	f << stringf(" := '0'");
 		n++;
 	}
 

--- a/backends/vhdl/vhdl_backend.cc
+++ b/backends/vhdl/vhdl_backend.cc
@@ -2548,7 +2548,10 @@ void dump_component(std::ostream &f, std::string indent, RTLIL::Cell *cell){
 			
 			if ((param.second.flags & RTLIL::CONST_FLAG_STRING) != 0)
 				f << stringf("string := \"%s\"",param.second.decode_string().c_str());
-
+			else if ((param.second.flags & RTLIL::CONST_FLAG_SIGNED) != 0)
+				f << stringf("integer := 0");
+			else if ((param.second.flags & RTLIL::CONST_FLAG_REAL) != 0)
+				f << stringf("real := 0.0");
 			else if (param.second.size()>1){
 				f << stringf("std_logic_vector (%d downto 0)",param.second.size()-1);
 			}


### PR DESCRIPTION
Hi @thierryBesson 

Parameter of [type string](https://github.com/os-fpga/yosys-rs-plugin/blob/main/genesis3/cells_sim.vhd#L355) was not handled before, I put std_logic_vector(n downto 0) for string parameter as well, This is fixed.

Also, Can you please tell me when do we use paramter type, 

1. integer
2. std_logic
      
Currently std_logic and string paramters are only handled.

Also, I see in old implementation for some input port, you intialize the port [with zero](https://github.com/os-fpga/yosys_rs/commit/68ff05e0e1197b2a18b9a5db9e91e27dac677d77#diff-9ca13e23b49f1d0b91ece5c79df02c97e4f38f5d52d6b37f03c2a4e7b44bf939L2708) and for some [not intialize](https://github.com/os-fpga/yosys_rs/commit/68ff05e0e1197b2a18b9a5db9e91e27dac677d77#diff-9ca13e23b49f1d0b91ece5c79df02c97e4f38f5d52d6b37f03c2a4e7b44bf939L2683), why so?

As, in my implementation ghdl simulator errors out if I initialize input ports with zero,

![image](https://github.com/user-attachments/assets/3a93aecb-fa96-4820-bd3a-d04d3a5ab18c)

here is the error message, So, I want to know the criteria for initialization here, for now I have [commented](https://github.com/os-fpga/yosys_rs/compare/master...awaisabbas006:yosys_rs:master?expand=1#diff-9ca13e23b49f1d0b91ece5c79df02c97e4f38f5d52d6b37f03c2a4e7b44bf939R2579) the initialization for input port and I no longer gets the error.

For now, with this fix, CI is clean, I ran 

1. make test/batch_all
2. counter_vhdl
3. GJC test