### PR TITLE
Revert "fix potential non-determinism in verilog/vhdl dumpers"

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -2625,8 +2625,6 @@ struct VerilogBackend : public Backend {
 		auto_name_map.clear();
 		reg_wires.clear();
 
-		design->sort();
-
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			std::string arg = args[argidx];

--- a/backends/vhdl/vhdl_backend.cc
+++ b/backends/vhdl/vhdl_backend.cc
@@ -2936,8 +2936,6 @@ struct VhdlBackend : public Backend {
 		auto_name_map.clear();
 		reg_wires.clear();
 
-		design->sort();
-
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			std::string arg = args[argidx];


### PR DESCRIPTION
Reverts os-fpga/yosys_rs#161

@BessonThierry , this PR breaks the test:
./build/bin/raptor --batch  --script tests/Testcases/counter_vhdl/raptor.tcl

INFO: SGT: ##################################################
INFO: SGT: Gate simulation for design: counter_vhdl_gemini
INFO: SGT: ##################################################
Command: /home/alain/os-fpga/Raptor/build/bin/HDL_simulator/GHDL/bin/ghdl -a -fsynopsys -fexplicit --std=08 /home/alain/os-fpga/Raptor/tests/Testcases/counter_vhdl/testbench.vhd /home/alain/os-fpga/Raptor/counter_vhdl_gemini/run_1/synth_1_1/synthesis/counter_vhdl_gemini_post_synth.vhd /home/alain/os-fpga/Raptor/build/share/raptor/sim_models/rapidsilicon/genesis3/cells_sim.vhd
/home/alain/os-fpga/Raptor/counter_vhdl_gemini/run_1/synth_1_1/synthesis/counter_vhdl_gemini_post_synth.vhd:30:48: can't match character literal '0' with type array type "STD_ULOGIC_VECTOR"
       A : in std_logic_vector (4 downto 0) := '0';
                                               ^
/home/alain/os-fpga/Raptor/counter_vhdl_gemini/run_1/synth_1_1/synthesis/counter_vhdl_gemini_post_synth.vhd:39:48: can't match character literal '0' with type array type "STD_ULOGIC_VECTOR"
       A : in std_logic_vector (3 downto 0) := '0';
                                               ^
/home/alain/os-fpga/Raptor/counter_vhdl_gemini/run_1/synth_1_1/synthesis/counter_vhdl_gemini_post_synth.vhd:48:48: can't match character literal '0' with type array type "STD_ULOGIC_VECTOR"
       A : in std_logic_vector (1 downto 0) := '0';
                                               ^
/home/alain/os-fpga/Raptor/counter_vhdl_gemini/run_1/synth_1_1/synthesis/counter_vhdl_gemini_post_synth.vhd:57:48: can't match character literal '0' with type array type "STD_ULOGIC_VECTOR"
       A : in std_logic_vector (2 downto 0) := '0';
                                               ^
/home/alain/os-fpga/Raptor/counter_vhdl_gemini/run_1/synth_1_1/synthesis/counter_vhdl_gemini_post_synth.vhd:168:3: no actual for constant interface "WEAK_KEEPER"
  RS_20 : I_BUF 
  ^
/home/alain/os-fpga/Raptor/counter_vhdl_gemini/run_1/synth_1_1/synthesis/counter_vhdl_gemini_post_synth.vhd:174:3: no actual for constant interface "WEAK_KEEPER"
  RS_21 : I_BUF 
  ^
