### PR TITLE
fix confusing message about DE eventual error

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1268,7 +1268,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		std::ifstream ifs;
 		ifs.open(buffer);
 		if (ifs.fail())
-			log_error("Something went wrong in DE LUT mapper.\n");
+			log_error("Something went wrong in ABC run.\n");
 
 		bool builtin_lib = liberty_files.empty() && genlib_files.empty();
 		RTLIL::Design *mapped_design = new RTLIL::Design;


### PR DESCRIPTION
when error happens in generic ABC optimization, previous error message reported it as it was in DE.