### PR TITLE
reduce runtime blow up in sat-based DFF optimization for EDA-3310

### DIFF
--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -772,6 +772,13 @@ log("Nb solve = %d\n", nbSolve);
 			// Now check if any bit can be replaced by a constant.
 			pool<int> removed_sigbits;
 			for (int i = 0; i < ff.width; i++) {
+
+                                // Avoid runtime explosion in SAT solver (ex: EDA-3310)
+                                //
+                                if (i >= 128) {
+                                  break;
+                                }
+
 				State val = ff.val_init[i];
 				if (ff.has_arst)
 					val = combine_const(val, ff.val_arst[i]);


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Runtime blow up in EDA-3310

_Explain how this is achieved._
We generally handle not more than 128 bits DFF signal and we exit after that value because in this case we get 10000 such dffs several times and it blows up runtime. It has no QoR consquences on regular designs.

_If applicable, please suggest to reviewers how they can test the change._
Not really applicable in general only on EDA--3310 where it will help to complete the run in 3 hours.

'test/batch_all" have completed successfully