### PR TITLE
fix for EDA-3310, map distributed mem to logic

### DIFF
--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -572,7 +572,8 @@ void MemMapping::determine_style() {
 			if (val_s == "auto") {
 				// Nothing.
 			// } else if (val_s == "logic" || val_s == "registers") {
-			} else if (val_s == "logic" || val_s == "registers" || val_s == "pipe_distributed") { // Awais: pipe_distributed ram kind is mapped to logic 
+			} else if (val_s == "logic" || val_s == "registers" || val_s == "pipe_distributed" || val_s == "distributed") { // Awais: pipe_distributed ram kind is mapped to logic 
+				//Awais: map distributed memory to logic, not supported in architecture.
 				kind = RamKind::Logic;
 				log("found attribute '%s = %s' on memory %s.%s, forced mapping to FF\n", log_id(attr), val_s.c_str(), log_id(mem.module->name), log_id(mem.memid));
 			} else if (val_s == "distributed") {


### PR DESCRIPTION
The RS FPGA architecture lacks distributed memory. Applying the attribute rom_style="distributed" in the design forces Yosys to map it to distributed memory, which is unavailable on this architecture. Therefore, the rom_style attribute has been changed to "logic" to map the memory onto LUTs/DFFs instead.

The test/batch_all has been tested in Raptor.